### PR TITLE
Messing around

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea/
 target/
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
       <artifactId>camel-test-spring</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>com.github.stefanbirkner</groupId>
+        <artifactId>system-rules</artifactId>
+        <version>1.18.0</version>
+        <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/src/main/java/poc/mdc/MDCEnricher.java
+++ b/src/main/java/poc/mdc/MDCEnricher.java
@@ -1,10 +1,11 @@
 package poc.mdc;
 
+import org.apache.camel.Header;
 import org.slf4j.MDC;
 
 public class MDCEnricher {
 
-  public void enrich() {
-    MDC.put("enrich.me", "Enriched");
+  public void enrich(@Header("enrich.me") String enrich) {
+    MDC.put("enrich.me", enrich);
   }
 }

--- a/src/main/resources/META-INF/spring/camel-context.xml
+++ b/src/main/resources/META-INF/spring/camel-context.xml
@@ -19,17 +19,20 @@
     <route id="in-route">
       <from uri="direct:in-route"/>
       <!-- bean ref="mdcLogger" method="log"/ -->
+      <log message="${body}" />
       <bean ref="mdcTester" method="interruptWhenMDCEnriched"/>
       <bean ref="mdcEnricher" method="enrich"/>
       <setHeader headerName="enrich.me">
         <constant>Enriched</constant>
       </setHeader>
       <!-- bean ref="mdcLogger" method="log"/ -->
+      <log message="${body}" />
       <wireTap uri="direct:in-wiretap"/>
       <to uri="direct:out-route"/>
       <split parallelProcessing="true">
         <simple>${body}</simple>
         <!-- bean ref="mdcLogger" method="log"/ -->
+        <log message="${body}" />
         <bean ref="mdcTester" method="interruptWhenMDCNotEnriched"/>
         <to uri="mock:end-of-split"/>
       </split>
@@ -40,6 +43,7 @@
     <route id="in-wiretap">
       <from uri="direct:in-wiretap"/>
       <!-- bean ref="mdcLogger" method="log"/ -->
+      <log message="${body}" />
       <bean ref="mdcTester" method="interruptWhenMDCNotEnriched"/>
       <to uri="mock:end-of-in-wiretap-route"/>
     </route>
@@ -47,6 +51,7 @@
     <route id="out-route">
       <from uri="direct:out-route"/>
       <!-- bean ref="mdcLogger" method="log"/ -->
+      <log message="${body}" />
       <bean ref="mdcTester" method="interruptWhenMDCNotEnriched"/>
       <to uri="mock:end-of-out-route"/>
     </route>

--- a/src/main/resources/META-INF/spring/camel-context.xml
+++ b/src/main/resources/META-INF/spring/camel-context.xml
@@ -18,14 +18,12 @@
 
     <route id="in-route">
       <from uri="direct:in-route"/>
-      <!-- bean ref="mdcLogger" method="log"/ -->
       <log message="${body}" />
       <bean ref="mdcTester" method="interruptWhenMDCEnriched"/>
-      <bean ref="mdcEnricher" method="enrich"/>
       <setHeader headerName="enrich.me">
         <constant>Enriched</constant>
       </setHeader>
-      <!-- bean ref="mdcLogger" method="log"/ -->
+      <bean ref="mdcEnricher" method="enrich"/>
       <log message="${body}" />
       <wireTap uri="direct:in-wiretap"/>
       <to uri="direct:out-route"/>
@@ -42,15 +40,30 @@
 
     <route id="in-wiretap">
       <from uri="direct:in-wiretap"/>
-      <!-- bean ref="mdcLogger" method="log"/ -->
       <log message="${body}" />
       <bean ref="mdcTester" method="interruptWhenMDCNotEnriched"/>
       <to uri="mock:end-of-in-wiretap-route"/>
     </route>
+    
+    
+    <route id="in-filter">
+      <from uri="direct:in-filter" />
+      <log message="${body}" />
+        <setHeader headerName="enrich.me">
+          <constant>Enriched-in-filter</constant>
+        </setHeader>
+        <bean ref="mdcEnricher" method="enrich"/>
+      <filter>
+        <simple resultType="java.lang.Boolean">true</simple>
+        <log message="${body}" />
+      </filter>
+      <bean ref="mdcTester" method="interruptWhenMDCNotEnriched"/>
+      <log message="${body}" />
+      <to uri="mock:end-of-in-filter-route"/>
+    </route>
 
     <route id="out-route">
       <from uri="direct:out-route"/>
-      <!-- bean ref="mdcLogger" method="log"/ -->
       <log message="${body}" />
       <bean ref="mdcTester" method="interruptWhenMDCNotEnriched"/>
       <to uri="mock:end-of-out-route"/>

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -2,6 +2,6 @@
 appender.out.type = Console
 appender.out.name = out
 appender.out.layout.type = PatternLayout
-appender.out.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %-30.30X{camel.exchangeId} - %-30.30X{camel.breadcrumbId} - %m%n
+appender.out.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %-30.30X{camel.exchangeId} - %-30.30X{camel.breadcrumbId} - %X{enrich.me} %m%n
 rootLogger.level = INFO
 rootLogger.appenderRef.out.ref = out

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -2,6 +2,6 @@
 appender.out.type = Console
 appender.out.name = out
 appender.out.layout.type = PatternLayout
-appender.out.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %-30.30X{camel.exchangeId} - %-30.30X{camel.breadcrumbId} - %X{enrich.me} %m%n
+appender.out.layout.pattern = %d [%-15.15t] %-5p %-30.30c{1} - %-30.30X{camel.exchangeId} - %-30.30X{camel.breadcrumbId} - %10.10X{enrich.me} %m%n
 rootLogger.level = INFO
 rootLogger.appenderRef.out.ref = out

--- a/src/test/java/poc/mdc/RoutestTest.java
+++ b/src/test/java/poc/mdc/RoutestTest.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 
 @RunWith(CamelSpringRunner.class)
 @BootstrapWith(CamelTestContextBootstrapper.class)
-// @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @ContextConfiguration(locations = {"classpath*:META-INF/spring/camel-context.xml"})
 public class RoutestTest {
 
@@ -29,6 +28,12 @@ public class RoutestTest {
 
   @Produce(uri = "direct:in-route")
   private FluentProducerTemplate inRouteProducer;
+
+  @Produce(uri = "direct:in-filter")
+  private FluentProducerTemplate inFilterRouteProducer;
+
+  @EndpointInject(uri = "mock:end-of-in-filter-route")
+  private MockEndpoint mockEndOfInFilterRouteEndpoint;
 
   @EndpointInject(uri = "mock:end-of-in-route")
   private MockEndpoint mockEndOfInRouteEndpoint;
@@ -76,5 +81,12 @@ public class RoutestTest {
     mockEndOfSplitEndpoint.expectedMessageCount(2);
     inRouteProducer.withBody(Arrays.asList("msg1", "msg2")).send();
     mockEndOfSplitEndpoint.assertIsSatisfied();
+  }
+
+  @Test
+  public void endOfInFilterRouteShouldReceiveAnEnrichedMessage() throws Exception {
+    mockEndOfInFilterRouteEndpoint.expectedMessageCount(1);
+    inFilterRouteProducer.withBody(Arrays.asList("msg1", "msg2")).send();
+    mockEndOfInFilterRouteEndpoint.assertIsSatisfied();
   }
 }

--- a/src/test/java/poc/mdc/RoutestTest.java
+++ b/src/test/java/poc/mdc/RoutestTest.java
@@ -1,23 +1,31 @@
 package poc.mdc;
 
-import java.util.Arrays;
+import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
 import org.apache.camel.FluentProducerTemplate;
 import org.apache.camel.Produce;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.CamelSpringRunner;
 import org.apache.camel.test.spring.CamelTestContextBootstrapper;
+import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.runner.RunWith;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.BootstrapWith;
 import org.springframework.test.context.ContextConfiguration;
+import java.util.Arrays;
 
 @RunWith(CamelSpringRunner.class)
 @BootstrapWith(CamelTestContextBootstrapper.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+// @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @ContextConfiguration(locations = {"classpath*:META-INF/spring/camel-context.xml"})
 public class RoutestTest {
+
+  @Rule
+  public final EnvironmentVariables environmentVariables =
+      new EnvironmentVariables().set("CLEAR_MDC", "true");
 
   @Produce(uri = "direct:in-route")
   private FluentProducerTemplate inRouteProducer;
@@ -33,6 +41,14 @@ public class RoutestTest {
 
   @EndpointInject(uri = "mock:end-of-split")
   private MockEndpoint mockEndOfSplitEndpoint;
+
+  @Autowired
+  private CamelContext camelContext;
+
+  @After
+  public void resetMockEndpoints() {
+    MockEndpoint.resetMocks(camelContext);
+  }
 
   @Test
   public void endOfInRouteShouldReceiveAnEnrichedMessage() throws Exception {


### PR DESCRIPTION
Use dynamic value for the header (this uncovered the order of set header and log was wrong in one rute). Use log in the route instead of calling a bean to log. Add the "enrich.me" in the log configuration.
Do not reload context on the test.
Add test case for addheader+NDC+filter